### PR TITLE
Fix segfault in sample.c due to analigned access caused by strcpy

### DIFF
--- a/sample/sample.c
+++ b/sample/sample.c
@@ -247,7 +247,10 @@ static int send_ctrl_msg(const uint8_t instance)
 	 * in SRAM and A53 will complain about unaligned accesses.
 	 */
 	sprintf(tmp, "SENDING MESSAGES: %d", app.num_msgs);
-	strcpy(app.ctrl_shm, tmp);
+
+	char *src = tmp;
+	char *dst = app.ctrl_shm;
+	while((*dst++ = *src++) != '\0');
 
 	sample_info("ch %d >> %ld bytes: %s\n", chan_id, strlen(tmp), tmp);
 
@@ -278,7 +281,10 @@ static void generate_msg(char *s, int len, int msg_no)
 	 * in SRAM and A53 will complain about unaligned accesses.
 	 */
 	sprintf(tmp, "#%d HELLO WORLD! from KERNEL", msg_no);
-	strcpy(s, tmp);
+
+	char *src = tmp;
+	char *dst = s;
+	while((*dst++ = *src++) != '\0');
 }
 
 /**


### PR DESCRIPTION
The strcpy calls in sample.c caused segmentation fault on kernels with CONFIG_FORTIFY_SOURCE enabled. This occurs because strcpy is compiled as a memcpy (preceded by a strlen), which violates memory alignment constraints and lead to a crash.

To resolve the issue, all strcpy calls in sample.c were replaced with a byte-by-byte copy, ensuring that no unaligned access occurs.

Tested on both kernels with and without CONFIG_FORTIFY_SOURCE to ensure compatibility and to confirm that the changes prevent the segfault.